### PR TITLE
[fix/unsupported-toolchain] Moved from rv64gh to rv64gc

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -17,7 +17,9 @@ LD		?=	ld
 AS		?=	as
 endif
 
-ARCH ?= $(shell if [ `$(CC) -dumpversion | cut -f1 -d.` -lt 13 ]; then echo rv64gc; else echo rv64gh; fi)
+# Since only newer (version >13) toolchains supports the 'H' extension of the ISA, we fallback to `gc` for older ones.
+# This should not be a problem for an hypervisor/virtualization software.
+ARCH ?= $(shell if [ `$(CC) -dumpversion | cut -f1 -d.` -lt 13 ]; then echo rv64gc; else echo rv64gch; fi)
 ABI ?= lp64
 
 CFLAGS  = -Wall -Wextra -march=$(ARCH) -mabi=$(ABI)

--- a/config.mk
+++ b/config.mk
@@ -17,7 +17,7 @@ LD		?=	ld
 AS		?=	as
 endif
 
-# Since only newer (version >13) toolchains supports the 'H' extension of the ISA, we fallback to `gc` for older ones.
+# Since only newer (version >=13) toolchains supports the 'H' extension of the ISA, we fallback to `gc` for older ones.
 # This should not be a problem for an hypervisor/virtualization software.
 ARCH ?= $(shell if [ `$(CC) -dumpversion | cut -f1 -d.` -lt 13 ]; then echo rv64gc; else echo rv64gch; fi)
 ABI ?= lp64

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,7 @@ ifdef CROSS_COMPILE
 CC		=	$(CROSS_COMPILE)gcc
 AR		=	$(CROSS_COMPILE)ar
 LD		=	$(CROSS_COMPILE)ld
-AS 		= $(CROSS_COMPILE)as
+AS		= $(CROSS_COMPILE)as
 else
 CC		?=	gcc
 AR		?=	ar
@@ -17,7 +17,7 @@ LD		?=	ld
 AS		?=	as
 endif
 
-ARCH ?= rv64gc
+ARCH ?= $(shell if [ `$(CC) -dumpversion | cut -f1 -d.` -lt 13 ]; then echo rv64gc; else echo rv64gh; fi)
 ABI ?= lp64
 
 CFLAGS  = -Wall -Wextra -march=$(ARCH) -mabi=$(ABI)

--- a/config.mk
+++ b/config.mk
@@ -1,7 +1,7 @@
 # Centralized file to manage build variables. This will be included in example, tests and scripts.
 # Usage:
 # 	When compiling use CROSS_COMPILE to pass the start of your ie. toolchain
-# 	eg. make CROSS_COMPILE=riscv64-linux-musl-
+# 	eg. make CROSS_COMPILE=riscv64-linux-gnu-
 # Authors:
 # 	Giuseppe Capasso <capassog97@gmail.com>
 
@@ -17,7 +17,7 @@ LD		?=	ld
 AS		?=	as
 endif
 
-ARCH ?= rv64gh
+ARCH ?= rv64gc
 ABI ?= lp64
 
 CFLAGS  = -Wall -Wextra -march=$(ARCH) -mabi=$(ABI)

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,7 @@ ifdef CROSS_COMPILE
 CC		=	$(CROSS_COMPILE)gcc
 AR		=	$(CROSS_COMPILE)ar
 LD		=	$(CROSS_COMPILE)ld
-AS		= $(CROSS_COMPILE)as
+AS		=	$(CROSS_COMPILE)as
 else
 CC		?=	gcc
 AR		?=	ar


### PR DESCRIPTION
# Description
This solves #8.
After deeply investigating, it looks like we don't need the `h` in the `-march`. In fact, looking at other projects which implements hypervisors and virtualization functions, they use the `rv64gc` tag:
- https://github.com/xvisor/xvisor/blob/master/arch/riscv/cpu/generic/objects.mk
- https://github.com/diodesign/diosix/blob/main/docs/running.md
- https://github.com/stemnic/rustyvisor
- https://github.com/lmt-swallow/rvvisor

With this PR the, the `rv64gh` is used only for toolchains with version > 13.