### PR TITLE
[feature/docker-setup] Setting up docker environment 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,21 @@ shadowfax says: 5 + 4 = 9
 ```
 
 ### Unsupported distributions
-If your distribution is not supported by the script, you can install required dependencies
-by yourself. You need:
+If your distribution is not supported by the script, you can install required dependencies by yourself or refer to the [Docker setup](#docker-setup). You need:
 
 - a riscv64 toolchain: to compile source code and examples;
 - qemu (for riscv64): to run programs in an emulated machine;
-- make: to assemble projects;
+- dependencies to build the Linux Kernel;
+- rust with the riscv64gc target;
+
+### Docker setup
+For unsupported distributions or for users that want a consistent build environment,
+a debian-based Docker image can be built and executed in container with:
+using `scripts/Dockerfile.setup`:
+```sh
+docker build -t shadowfax-build < scripts/Dockerfile.setup
+docker run -v $(pwd):/shadowfax -w /shadowfax --network=host -it shadowfax-build
+```
 
 ## Contributing
 This repository uses [pre-commit](https://pre-commit.com/). Before contributing, setup your environment

--- a/scripts/Dockerfile.setup
+++ b/scripts/Dockerfile.setup
@@ -1,0 +1,30 @@
+# The goal of this Dockerfile is to build a consistent build environment.
+# The base image is debian:12.
+# Project dependencies are:
+# - rust toolchain (with riscv64gc target)
+# - gcc riscv toolchain
+# - shell utils to build Linux kernel
+# - qemu
+#
+# Usage: run this image in a container mounting the project directory as a bind
+# volume.
+#
+#   docker build -t shadowfax-build < scripts/Dockerfile.setup
+#   docker run -v $(pwd):/shadowfax -w /shadowfax --network=host -it shadowfax-build
+#
+# Author: Giuseppe Capsso <capassog97@gmail.com>
+
+FROM debian:12
+
+# Install dependencies
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt -y install make qemu-system \
+      gcc-riscv64-linux-gnu build-essential libncurses-dev bison flex libssl-dev \
+      libelf-dev dwarves curl git file
+
+# Install and setup rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+RUN echo 'source $HOME/.cargo/env' >> /root/.bashrc
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN rustup target add riscv64gc-unknown-none-elf


### PR DESCRIPTION
# Description
This PR adds  `scripts/Dockerfile.setup` to build a debian-based Docker image to have a consistent build environment. An image can be built and executed with:

```sh
docker build -t shadowfax-build < scripts/Dockerfile.setup
docker run -v $(pwd):/shadowfax -w /shadowfax --network=host -it shadowfax-build
```