### PR TITLE
[feature/precommit-ci] Added workflow to use pre-commit in CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,21 @@
+# This is taken from: https://pre-commit.ci/lite.html
+# The actions applies configuration from pre-commit using
+# .pre-commit-config.yml to ensure code-style, quality ecc
+name: Pre-commit CI
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit-ci/lite-action@v1.1.0
+      if: always()


### PR DESCRIPTION
# Description
This PR adds the github action for pre-commit ci. However, if we want to use this we **must** enable the Github Application from https://pre-commit.ci/lite.html.

## Alternative
We can make a custom action that just fails, if pre-commit does not pass.