### PR TITLE
[feature/vmm tsm shmem] - A more structured host-TSM interaction

### DIFF
--- a/payload/tsm/src/main.rs
+++ b/payload/tsm/src/main.rs
@@ -45,7 +45,7 @@ extern "C" fn entry() -> ! {
             stack_size_per_hart = const STACK_SIZE_PER_HART,
             stack_top = sym _top_b_stack,
             main = sym main,
-            options(noreturn)
+            options(noreturn, nostack)
         )
     }
 }
@@ -56,24 +56,13 @@ const COVE_TSM_CAP_PROMOTE_TVM: usize = 0x0;
 const COVE_TSM_CAP_ATTESTATION_LOCAL: usize = 0x1;
 
 // Since this is a TSM with non reentrant model, an ECALL should be a TEERET
-fn main() -> ! {
+fn main(a0: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> ! {
     let mut a6: usize;
     unsafe { core::arch::asm!("add {}, a6, zero", out(reg) a6, options(nomem)) };
     let (_sdid, fid) = cove_unpack_fid!(a6);
     match fid {
         SBI_COVH_GET_TSM_INFO => {
-            let mut tsm_info_addr: usize;
-            let mut tsm_info_size: usize;
-            unsafe {
-                core::arch::asm!(
-                "add {}, a0, zero",
-                "add {}, a1, zero",
-                out(reg) tsm_info_addr,
-                out(reg)tsm_info_size,
-                options(nomem, nostack)
-                )
-            };
-            let tsm_info_ptr = tsm_info_addr as *mut TsmInfo;
+            let tsm_info_ptr = a0 as *mut TsmInfo;
             let state = TsmInfo {
                 tsm_state: TsmState::TsmReady,
                 tsm_impl_id: 69,
@@ -87,7 +76,7 @@ fn main() -> ! {
 
             unsafe { tsm_info_ptr.write(state) }
 
-            assert_eq!(tsm_info_size, core::mem::size_of::<TsmInfo>());
+            assert_eq!(a1, core::mem::size_of::<TsmInfo>());
         }
         _ => {}
     }

--- a/platform/generic/memory.x
+++ b/platform/generic/memory.x
@@ -90,7 +90,6 @@ SECTIONS {
     /* Heap used by tsm-driver */
     _tee_heap_start = .;
     . += _heap_size;
-    . = ALIGN(4K);
     /* Scratch memory for CoVE interrupt handling and interrupt handling*/
     . = ALIGN(4K);
     . += _tee_stack_size;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@
 #![no_main]
 #![feature(fn_align)]
 #![feature(once_cell_get_mut)]
+#![feature(naked_functions_rustic_abi)]
+
 use core::{ffi, panic::PanicInfo};
 
 use linked_list_allocator::LockedHeap;

--- a/src/sbi/mod.rs
+++ b/src/sbi/mod.rs
@@ -8,3 +8,5 @@ pub struct SbiRet {
     pub error: isize,
     pub value: isize,
 }
+
+pub const SBI_COVH_GET_TSM_INFO: usize = 0;

--- a/src/shadowfax_core/state.rs
+++ b/src/shadowfax_core/state.rs
@@ -216,8 +216,8 @@ pub struct Context {
     scontext: usize,
     pub mepc: usize,
 
-    pmpcfg: usize,
-    pmpaddr: [usize; 16],
+    pub pmpcfg: usize,
+    pub pmpaddr: [usize; 8],
     interrupted: usize,
 }
 

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -495,12 +495,11 @@ extern "C" fn tee_handler(fid: usize) -> ! {
 
                 let dst_ctx = dst_addr as *mut Context;
                 unsafe {
-                    // we need to preserve all a0-a7 registers without a5.
+                    // we need to preserve all a0-a7 registers.
                     // Easier (maybe to help prefetch to store everything and to delete a5)
                     for i in 10..18 {
                         (*dst_ctx).regs[i] = (*src_ctx).regs[i];
                     }
-                    (*dst_ctx).regs[15] = 0;
                 }
 
                 state.domains[active_domain_id].active = 0;
@@ -529,7 +528,7 @@ extern "C" fn tee_handler(fid: usize) -> ! {
                         // calculate the pmpcfg byte
                         let locked = false;
                         let range = riscv::register::Range::NAPOT as usize;
-                        let perm = riscv::register::Permission::RW as usize;
+                        let perm = riscv::register::Permission::W as usize;
                         let slot = 7;
                         let cfg_byte = ((locked as usize) << 7) | (range << 3) | perm;
 
@@ -648,6 +647,6 @@ fn tee_handler_exit() -> ! {
             fence
             fence.i
             mret
-            ",
+        ",
     )
 }


### PR DESCRIPTION
# Description
This PR tidies up the code in the trap handler and fixes the missing permission error in TSM when handling the `sbi_covh_get_tsm_info` function.

## Host - TSM interaction
The TSM-driver performs some operations depending on the `fid` during the context switch. In the case of `sbi_covh_get_tsm_info`, the TSM-driver creates a PMP entry to allow the TSM to write the memory region defined.

## Security fix
The TSM-drivers handles all TEECALL towards non confidential domains as they can host non TEE-aware OS and cause unexpected behavior leading to confidential issues or DoS scenarios.