### PR TITLE
feature/enforce trust relationship

### DIFF
--- a/platform/generic/device-tree.dts
+++ b/platform/generic/device-tree.dts
@@ -98,6 +98,13 @@
 		shadowfax-domains {
 			compatible = "shadowfax,domain,config";
 
+			untrusted-domain {
+				compatible = "shadowfax,domain,instance";
+				id = <0x0>;
+				trust = <0x1>;
+				tsm-type = "none";
+			};
+
 			trusted-domain {
 				compatible = "shadowfax,domain,instance";
 				id = <0x1>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,7 @@ extern "C" fn main(boot_hartid: usize, fdt_addr: usize) -> ! {
     };
 
     // initialize shadowfax state which will be used to handle the CoVE SBI
-    shadowfax_core::state::init(fdt_addr, next_stage_address).unwrap();
+    shadowfax_core::state::init(fdt_addr).unwrap();
 
     /*
      * This code initializes the scratch space, which is a per-HART data structure

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -465,61 +465,75 @@ extern "C" fn tee_handler(fid: usize) -> ! {
                 dst_addr
             }
             _ => {
-                // We need to store the calling context into the right structure
-                let src_ctx = (scratch_addr
-                    - (TEE_SCRATCH_SIZE + size_of::<Context>())
-                    - (active_domain_id + 1) * size_of::<Context>())
-                    as *mut Context;
-                unsafe {
-                    core::ptr::copy_nonoverlapping(scratch_ctx, src_ctx, 1);
-                }
-                let dst_addr = scratch_addr
-                    - (TEE_SCRATCH_SIZE + size_of::<Context>())
-                    - (dst_domain_id + 1) * size_of::<Context>();
+                // first check if there is a trust relationship between the two domains
+                if !active_domain.is_trusted(dst_domain_id) {
+                    let dst_addr = scratch_addr - (TEE_SCRATCH_SIZE + size_of::<Context>());
 
-                let dst_ctx = dst_addr as *mut Context;
-                unsafe {
-                    // we need to preserve all a0-a7 registers.
-                    // Easier (maybe to help prefetch to store everything and to delete a5)
-                    for i in 10..18 {
-                        (*dst_ctx).regs[i] = (*src_ctx).regs[i];
+                    let dst_ctx = dst_addr as *mut Context;
+                    unsafe {
+                        (*dst_ctx).regs[10] = usize::MAX;
+                        (*dst_ctx).regs[11] = 0;
+                        // increment mepc to avoid loop
+                        (*dst_ctx).mepc += 4;
                     }
-                }
+                    dst_addr
+                } else {
+                    // We need to store the calling context into the right structure
+                    let src_ctx = (scratch_addr
+                        - (TEE_SCRATCH_SIZE + size_of::<Context>())
+                        - (active_domain_id + 1) * size_of::<Context>())
+                        as *mut Context;
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(scratch_ctx, src_ctx, 1);
+                    }
+                    let dst_addr = scratch_addr
+                        - (TEE_SCRATCH_SIZE + size_of::<Context>())
+                        - (dst_domain_id + 1) * size_of::<Context>();
 
-                state.domains[active_domain_id].active = 0;
-                state.domains[dst_domain_id].active =
-                    (1 << active_domain_id) | (1 << dst_domain_id);
-
-                // Perform operations to allow the specific functionality
-                match fid {
-                    // For sbi_covh_get_tsm_info we need to give the TSM access to the memory space
-                    // where he will write the tsm_info struct (a0) for the necessary size (a1).
-                    cove::SBI_COVH_GET_TSM_INFO => {
-                        let addr = unsafe { (*dst_ctx).regs[10] };
-                        let size = unsafe { (*dst_ctx).regs[11] };
-
-                        let slot = 2;
-
-                        // Build the CFG byte for TOR + RW (not locked)
-                        let range = riscv::register::Range::TOR as usize;
-                        let perm = riscv::register::Permission::RW as usize;
-                        let locked = false as usize;
-                        let cfg_byte = (locked << 7) | (range << 3) | (perm);
-
-                        // Mask out old byte for slot 1 in pmpcfg0
-                        let byte_mask = 0xff << (slot * 8);
-
-                        unsafe {
-                            (*dst_ctx).pmpaddr[slot - 1] = addr >> 2;
-                            (*dst_ctx).pmpaddr[slot] = (addr + size) >> 2;
-
-                            (*dst_ctx).pmpcfg &= !byte_mask;
-                            (*dst_ctx).pmpcfg |= cfg_byte << (slot * 8);
+                    let dst_ctx = dst_addr as *mut Context;
+                    unsafe {
+                        // we need to preserve all a0-a7 registers.
+                        // Easier (maybe to help prefetch to store everything and to delete a5)
+                        for i in 10..18 {
+                            (*dst_ctx).regs[i] = (*src_ctx).regs[i];
                         }
                     }
-                    _ => {}
+
+                    state.domains[active_domain_id].active = 0;
+                    state.domains[dst_domain_id].active =
+                        (1 << active_domain_id) | (1 << dst_domain_id);
+
+                    // Perform operations to allow the specific functionality
+                    match fid {
+                        // For sbi_covh_get_tsm_info we need to give the TSM access to the memory space
+                        // where he will write the tsm_info struct (a0) for the necessary size (a1).
+                        cove::SBI_COVH_GET_TSM_INFO => {
+                            let addr = unsafe { (*dst_ctx).regs[10] };
+                            let size = unsafe { (*dst_ctx).regs[11] };
+
+                            let slot = 2;
+
+                            // Build the CFG byte for TOR + RW (not locked)
+                            let range = riscv::register::Range::TOR as usize;
+                            let perm = riscv::register::Permission::RW as usize;
+                            let locked = false as usize;
+                            let cfg_byte = (locked << 7) | (range << 3) | (perm);
+
+                            // Mask out old byte for slot 1 in pmpcfg0
+                            let byte_mask = 0xff << (slot * 8);
+
+                            unsafe {
+                                (*dst_ctx).pmpaddr[slot - 1] = addr >> 2;
+                                (*dst_ctx).pmpaddr[slot] = (addr + size) >> 2;
+
+                                (*dst_ctx).pmpcfg &= !byte_mask;
+                                (*dst_ctx).pmpcfg |= cfg_byte << (slot * 8);
+                            }
+                        }
+                        _ => {}
+                    }
+                    dst_addr
                 }
-                dst_addr
             }
         }
     };
@@ -734,7 +748,6 @@ fn supd_handler(fid: usize) -> ! {
         "
         mv sp, {target_domain}
         j {tee_handler_exit}
-
         ",
         target_domain  = in(reg) dst_addr,
         tee_handler_exit = sym supd_handler_exit,


### PR DESCRIPTION
# Description
This PR adds a simple way to specify for each supervisor domain the trust relationship. This happens through a bit map stored for each domain structure specified in the device tree:

```dts
untrusted-domain {
	compatible = "shadowfax,domain,instance";
	id = <0x0>;
	trust = <0x1 0x..n>;
	tsm-type = "none";
};
```

The domain struct has a trust map with a `is_trusted` method:

```rust
#[derive(Clone)]
pub struct Domain {
    pub id: usize,
    name: String,
    pub active: usize,
    pub tsm_type: TsmType,
    pub trust_map: usize,
}

impl Domain {
    pub fn is_trusted(&self, dst: usize) -> bool {
        self.trust_map & (1 << dst) != 0
    }
}
```